### PR TITLE
update to 2.181.0

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,4 @@
+anaconda_config_version: 1
+upstream_sources:
+  - pypi:
+      identifier: oci

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - python
     - pip
     - setuptools
-    - wheel
   run:
     - python
     - certifi
@@ -29,6 +28,12 @@ requirements:
     - urllib3 >=2.6.3
     - circuitbreaker >=1.3.1,<3.0.0
     - crc32c ==2.7.1
+  run_constrained:
+    # `adk` extra (Agent Development Kit)
+    - docstring_parser >=0.16
+    - pydantic >=2.10.6
+    - rich >=13.9.4
+    - mcp >=1.6.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,9 @@ about:
     libraries and API bindings for the full range of OCI services.
   license: Apache-2.0 OR UPL-1.0
   license_family: Apache
-  license_file: LICENSE.txt
+  license_file:
+    - LICENSE.txt
+    - THIRD_PARTY_LICENSES.txt
   doc_url: https://docs.oracle.com/en-us/iaas/tools/python/latest/index.html
   dev_url: https://github.com/oracle/oci-python-sdk
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,34 @@
 {% set name = "oci" %}
-{% set version = "2.91.0" %}
+{% set version = "2.181.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/oci-{{ version }}.tar.gz
-  sha256: 78459fcd6ef542cc5f11b9d8f9aaf01513f167fee8b7976bb655545cd2355cbb
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/oci-{{ version }}.tar.gz
+  sha256: 8d52a4a65bf0d20bbd59dc3248ed3747b409b5061bcf18e90f2e52f6049fd154
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - certifi
-    - cryptography >=3.2.1,<39.0.0
-    - pyopenssl >=17.5.0,<=22.1.0
+    - cryptography >=3.2.1,<50.0.0
+    - pyopenssl >=17.5.0,<27.0.0
     - python-dateutil >=2.5.3,<3.0.0
     - pytz >=2016.10
-    - circuitbreaker >=1.3.1,<2.0.0
+    - urllib3 >=2.6.3
+    - circuitbreaker >=1.3.1,<3.0.0
+    - crc32c ==2.7.1
 
 test:
   imports:
@@ -38,8 +41,14 @@ test:
 about:
   home: https://docs.oracle.com/en-us/iaas/tools/python/latest/index.html
   summary: Oracle Cloud Infrastructure Python SDK
+  description: |
+    The Oracle Cloud Infrastructure (OCI) Python SDK enables you to write code
+    to manage Oracle Cloud Infrastructure resources. It provides Python client
+    libraries and API bindings for the full range of OCI services.
   license: Apache-2.0 OR UPL-1.0
+  license_family: Apache
   license_file: LICENSE.txt
+  doc_url: https://docs.oracle.com/en-us/iaas/tools/python/latest/index.html
   dev_url: https://github.com/oracle/oci-python-sdk
 
 extra:


### PR DESCRIPTION
oci 2.181.0

**Destination channel:** defaults

Update the Oracle Cloud Infrastructure Python SDK (stale conda-forge fork, was 2.91.0). Leaf dependency for the axolotl epic PKG-14944 (via ocifs → axolotl).

### Links
- [Upstream source (v2.181.0)](https://github.com/oracle/oci-python-sdk/tree/v2.181.0)
- [PKG-16151](https://anaconda.atlassian.net/browse/PKG-16151) (sub-ticket)
- [PKG-14944](https://anaconda.atlassian.net/browse/PKG-14944) (epic)
- [PyPI](https://pypi.org/project/oci/2.181.0/)

### Explanation of changes
- Version 2.91.0 → 2.181.0.


[PKG-14944]: https://anaconda.atlassian.net/browse/PKG-14944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[PKG-16151]: https://anaconda.atlassian.net/browse/PKG-16151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
